### PR TITLE
Instance transform update fast path

### DIFF
--- a/anari/BarneyGlobalState.cpp
+++ b/anari/BarneyGlobalState.cpp
@@ -31,6 +31,13 @@ namespace barney_device {
     objectUpdates.lastSceneChange = helium::newTimeStamp();
   }
 
+  void BarneyGlobalState::markStructuralSceneChanged()
+  {
+    auto ts = helium::newTimeStamp();
+    objectUpdates.lastSceneChange = ts;
+    objectUpdates.lastStructuralChange = ts;
+  }
+
   bool Tether::allDevicesPresent()
   {
     for (auto dev : devices)

--- a/anari/BarneyGlobalState.h
+++ b/anari/BarneyGlobalState.h
@@ -67,6 +67,7 @@ namespace barney_device {
     struct ObjectUpdates
     {
       helium::TimeStamp lastSceneChange{0};
+      helium::TimeStamp lastStructuralChange{0};
     } objectUpdates;
 
     int slot = -1;
@@ -86,8 +87,9 @@ namespace barney_device {
 
     BarneyGlobalState(ANARIDevice d);
     ~BarneyGlobalState();
-    
+
     void markSceneChanged();
+    void markStructuralSceneChanged();
   };
 
   // Helper functions/macros ////////////////////////////////////////////////////

--- a/anari/Geometry.cpp
+++ b/anari/Geometry.cpp
@@ -168,7 +168,7 @@ namespace barney_device {
 
   void Geometry::markFinalized()
   {
-    deviceState()->markSceneChanged();
+    deviceState()->markStructuralSceneChanged();
     Object::markFinalized();
   }
 

--- a/anari/Group.cpp
+++ b/anari/Group.cpp
@@ -26,7 +26,7 @@ namespace barney_device {
 
   void Group::markFinalized()
   {
-    deviceState()->markSceneChanged();
+    deviceState()->markStructuralSceneChanged();
     Object::markFinalized();
   }
 

--- a/anari/Instance.cpp
+++ b/anari/Instance.cpp
@@ -48,6 +48,7 @@ namespace barney_device {
     }
     
     m_transform = xfm;
+    m_previousGroup = m_group.ptr;
     m_group = getParamObject<Group>("group");
   }
 
@@ -59,7 +60,10 @@ namespace barney_device {
 
   void Instance::markFinalized()
   {
-    deviceState()->markSceneChanged();
+    if (m_group.ptr != m_previousGroup)
+      deviceState()->markStructuralSceneChanged();
+    else
+      deviceState()->markSceneChanged();
     Object::markFinalized();
   }
 

--- a/anari/Instance.h
+++ b/anari/Instance.h
@@ -44,6 +44,7 @@ namespace barney_device {
   private:
     math::mat4 m_transform;
     helium::IntrusivePtr<Group> m_group;
+    const Group *m_previousGroup = nullptr;
   };
 
 } // namespace barney_device

--- a/anari/SpatialField.cpp
+++ b/anari/SpatialField.cpp
@@ -56,7 +56,7 @@ namespace barney_device {
 
   void SpatialField::markFinalized()
   {
-    deviceState()->markSceneChanged();
+    deviceState()->markStructuralSceneChanged();
     Object::markFinalized();
   }
 

--- a/anari/Surface.cpp
+++ b/anari/Surface.cpp
@@ -42,7 +42,7 @@ namespace barney_device {
 
   void Surface::markFinalized()
   {
-    deviceState()->markSceneChanged();
+    deviceState()->markStructuralSceneChanged();
     Object::markFinalized();
   }
 

--- a/anari/Volume.cpp
+++ b/anari/Volume.cpp
@@ -22,7 +22,7 @@ namespace barney_device {
 
   void Volume::markFinalized()
   {
-    deviceState()->markSceneChanged();
+    deviceState()->markStructuralSceneChanged();
     Object::markFinalized();
   }
 

--- a/anari/World.cpp
+++ b/anari/World.cpp
@@ -5,7 +5,6 @@
 #include "World.h"
 // std
 #include <algorithm>
-#include <set>
 #include <map>
 
 namespace barney_device {
@@ -33,7 +32,6 @@ namespace barney_device {
 
   World::~World()
   {
-    auto *state = deviceState();
     BANARI_TRACK_LEAKS(std::cout << "#banari: ~World deconstructing"
                        << std::endl);
     tetheredModel = {};
@@ -122,7 +120,7 @@ namespace barney_device {
       m_instances.push_back(m_zeroInstance.ptr);
   }
 
-    void World::markFinalized()
+  void World::markFinalized()
   {
     deviceState()->markSceneChanged();
     Object::markFinalized();
@@ -131,10 +129,31 @@ namespace barney_device {
 
   BNModel World::makeCurrent()
   {
-    auto *state = deviceState();
-
     buildBarneyModel();
     return tetheredModel->model;
+  }
+
+  void World::uploadInstanceAttributes(const InstanceAttributes &attributes)
+  {
+    auto barneyModel = tetheredModel->model;
+    int  slot    = deviceState()->slot;
+    auto context = deviceState()->tether->context;
+
+    for (int i = 0; i < Instance::Attributes::count; i++) {
+      if (m_attributesData[i]) {
+        bnRelease(m_attributesData[i]);
+        m_attributesData[i] = 0;
+      }
+      m_attributesData[i] =
+        bnDataCreate(context, slot, BN_FLOAT4,
+                     attributes[i].size(), attributes[i].data());
+    }
+
+    for (int i = 0; i < Instance::Attributes::count; i++) {
+      std::string attribName = std::string("attribute") + std::to_string(i);
+      bnSetInstanceAttributes(barneyModel, slot,
+                              attribName.c_str(), m_attributesData[i]);
+    }
   }
 
   void World::buildBarneyModel()
@@ -143,86 +162,108 @@ namespace barney_device {
     if (state->objectUpdates.lastSceneChange <= m_lastBarneyModelBuild)
       return;
 
-    reportMessage(ANARI_SEVERITY_DEBUG, "barney::World rebuilding model");
+    bool structural =
+      m_lastBarneyModelBuild == 0
+      || state->objectUpdates.lastStructuralChange > m_lastBarneyModelBuild;
 
+    if (structural) {
+      reportMessage(ANARI_SEVERITY_DEBUG, "barney::World full model rebuild");
+      fullRebuild();
+    } else {
+      reportMessage(ANARI_SEVERITY_DEBUG, "barney::World transform-only update");
+      transformOnlyUpdate();
+    }
+
+    m_lastBarneyModelBuild = helium::newTimeStamp();
+  }
+
+  void World::fullRebuild()
+  {
     auto barneyModel = tetheredModel->model;
-
     int  slot    = deviceState()->slot;
-    auto context = deviceState()->tether->context;
 
-    std::vector<const Group *> groups;
-    std::vector<BNGroup>       barneyGroups;
-    std::vector<BNTransform>   barneyTransforms;
-
-    groups.reserve(m_instances.size());
+    std::vector<BNGroup>     barneyGroups;
+    std::vector<BNTransform> barneyTransforms;
+    InstanceAttributes attributes;
     barneyGroups.reserve(m_instances.size());
     barneyTransforms.reserve(m_instances.size());
 
-    /*! arrays for the attributes - by default these are empty, they get
-      created/filled on demand if/when we find instance(s) that have
-      them */
-    std::map<const Group*,BNGroup> barneyGroupForAnariGroup;
-    std::vector<math::float4> attributes[Instance::Attributes::count];
-    std::vector<int> instIDs;
+    std::map<const Group *, BNGroup> groupDedup;
+
     for (auto inst : m_instances) {
       if (!inst) continue;
       const Group *ag = inst->group();
       if (!ag) continue;
-      BNGroup bg = 0;
-      if (barneyGroupForAnariGroup.find(ag) == barneyGroupForAnariGroup.end())
-        barneyGroupForAnariGroup[ag] = bg = ag->makeBarneyGroup();
-      else
-        bg = barneyGroupForAnariGroup[ag];
-      if (!bg) continue;
+
+      auto [it, inserted] = groupDedup.try_emplace(ag, nullptr);
+      if (inserted)
+        it->second = ag->makeBarneyGroup();
+      BNGroup bg = it->second;
+      if (!bg)
+        continue;
 
       BNTransform bt;
-      instIDs.push_back(inst->m_id);
       inst->writeTransform(&bt);
       barneyTransforms.push_back(bt);
       barneyGroups.push_back(bg);
-      if (inst->attributes)
-        for (int i=0;i<Instance::Attributes::count;i++) {
-          if (isnan(inst->attributes->values[i].x)) continue;
-
-          while (attributes[i].size() < barneyTransforms.size())
-            attributes[i].push_back(math::float4(NAN));
-          attributes[i].back() = inst->attributes->values[i];
-        }
+      if (!inst->attributes)
+        continue;
+      for (int i = 0; i < Instance::Attributes::count; i++) {
+        if (isnan(inst->attributes->values[i].x))
+          continue;
+        while (attributes[i].size() < barneyTransforms.size())
+          attributes[i].push_back(math::float4(NAN));
+        attributes[i].back() = inst->attributes->values[i];
+      }
     }
 
     assert(barneyModel);
-    bnSetInstances(barneyModel,
-                   slot,
-                   barneyGroups.data(),
-                   barneyTransforms.data(),
+    bnSetInstances(barneyModel, slot,
+                   barneyGroups.data(), barneyTransforms.data(),
                    (int)barneyGroups.size());
 
-    for (int i=0;i<Instance::Attributes::count;i++) {
-      if (m_attributesData[i]) {
-        // one way or another, release existing attribute - either it
-        // doesn't exist any more (->free) or it might have changed size
-        // (-> need realloc anyway)
-        bnRelease(m_attributesData[i]);
-        m_attributesData[i] = 0;
-      }
+    for (auto &[_, bg] : groupDedup)
+      bnRelease(bg);
 
-      m_attributesData[i]
-        = bnDataCreate(context,slot,BN_FLOAT4,
-                       attributes[i].size(),attributes[i].data());
-    }
-    for (int i=0;i<Instance::Attributes::count;i++) {
-      std::string attribName = std::string("attribute")+std::to_string(i);
-      bnSetInstanceAttributes(barneyModel,slot,
-                              attribName.c_str(),
-                              m_attributesData[i]);
-    }
-
+    uploadInstanceAttributes(attributes);
     bnBuild(barneyModel, slot);
+  }
 
-    for (auto it : barneyGroupForAnariGroup)
-      bnRelease(it.second);
+  void World::transformOnlyUpdate()
+  {
+    auto barneyModel = tetheredModel->model;
+    int  slot    = deviceState()->slot;
 
-    m_lastBarneyModelBuild = helium::newTimeStamp();
+    std::vector<BNTransform> barneyTransforms;
+    InstanceAttributes attributes;
+    barneyTransforms.reserve(m_instances.size());
+    for (auto &a : attributes)
+      a.clear();
+
+    for (auto inst : m_instances) {
+      if (!inst) continue;
+      if (!inst->group()) continue;
+
+      BNTransform bt;
+      inst->writeTransform(&bt);
+      barneyTransforms.push_back(bt);
+
+      if (!inst->attributes)
+        continue;
+      for (int i = 0; i < Instance::Attributes::count; i++) {
+        if (isnan(inst->attributes->values[i].x))
+          continue;
+        while (attributes[i].size() < barneyTransforms.size())
+          attributes[i].push_back(math::float4(NAN));
+        attributes[i].back() = inst->attributes->values[i];
+      }
+    }
+
+    assert(barneyModel);
+    uploadInstanceAttributes(attributes);
+    bnUpdateInstanceTransforms(barneyModel, slot,
+                               barneyTransforms.data(),
+                               (int)barneyTransforms.size());
   }
 
 } // namespace barney_device

--- a/anari/World.h
+++ b/anari/World.h
@@ -6,6 +6,7 @@
 
 #include "Array.h"
 #include "Instance.h"
+#include <array>
 
 namespace barney_device {
 
@@ -27,7 +28,13 @@ namespace barney_device {
     void markFinalized() override;
 
   private:
+    using InstanceAttributes
+      = std::array<std::vector<math::float4>, Instance::Attributes::count>;
+
     void buildBarneyModel();
+    void uploadInstanceAttributes(const InstanceAttributes &attributes);
+    void fullRebuild();
+    void transformOnlyUpdate();
 
     helium::ChangeObserverPtr<ObjectArray> m_zeroSurfaceData;
     helium::ChangeObserverPtr<ObjectArray> m_zeroVolumeData;
@@ -39,8 +46,6 @@ namespace barney_device {
 
     std::vector<Instance *> m_instances;
 
-    // BNModel m_barneyModel{nullptr};
-    // int uniqueID = -1;
     TetheredModel::SP tetheredModel;
 
     BNData m_attributesData[Instance::Attributes::count] = {0,0,0,0,0};

--- a/anari/light/Light.cpp
+++ b/anari/light/Light.cpp
@@ -34,8 +34,7 @@ Light *Light::createInstance(std::string_view subtype, BarneyGlobalState *s)
 
 void Light::markFinalized()
 {
-  // NOTE: shouldn't need to override this to cause a BNContext rebuild...
-  deviceState()->markSceneChanged();
+  deviceState()->markStructuralSceneChanged();
   Object::markFinalized();
 }
 

--- a/barney/GlobalModel.h
+++ b/barney/GlobalModel.h
@@ -41,11 +41,16 @@ namespace BARNEY_NS {
                       int numInstances) override
     { getSlot(slot)->setInstances(groups,xfms,numInstances); }
 
+    void updateInstanceTransforms(int slot,
+                                  const affine3f *xfms,
+                                  int numInstances) override
+    { getSlot(slot)->updateInstanceTransforms(xfms,numInstances); }
+
     void setInstanceAttributes(int slot,
                                const std::string &which,
                                Data::SP data) override
     { getSlot(slot)->setInstanceAttributes(which,data?data->as<PODData>():PODData::SP{}); }
-    
+
     void build(int slot) override
     { getSlot(slot)->build(); }
       

--- a/barney/ModelSlot.cpp
+++ b/barney/ModelSlot.cpp
@@ -86,34 +86,25 @@ namespace BARNEY_NS {
       std::cout << "#barney: un-recognized instance attribute '" << which << "'" << std::endl;
       ;
   }
-  
-  void ModelSlot::build()
-  {
-    std::vector<affine3f> rtcTransforms;
-    EnvMapLight::SP envMapLight;
 
-    // ==================================================================
-    // generate all lights's "raw" data. note this is NOT per device
-    // (yet), even though the use of 'DD's seems to imply so. this
-    // should "eventually" be changed to something where the current
-    // 'world' class gets merged into 'modelslot', and all light,
-    // material, and texture data then live 'per logical device'
-    // ==================================================================
+  void ModelSlot::updateWorldLightsFromInstances()
+  {
     std::vector<QuadLight::DD> quadLights;
     std::vector<DirLight::DD>  dirLights;
-    std::vector<PointLight::DD>  pointLights;
+    std::vector<PointLight::DD> pointLights;
     std::pair<EnvMapLight::SP,affine3f> envLight;
-    
-    for (int i=0;i<instances.groups.size();i++) {
+
+    for (int i = 0; i < (int)instances.groups.size(); i++) {
       Group *group = instances.groups[i].get();
-      if (!group) continue;
-      if (!group->lights) continue;
+      if (!group || !group->lights)
+        continue;
       for (auto &light : group->lights->items) {
-        if (!light) continue;
+        if (!light)
+          continue;
         if (QuadLight::SP quadLight = light->as<QuadLight>()) {
           quadLights.push_back(quadLight->getDD(instances.xfms[i]));
           continue;
-        } 
+        }
         if (DirLight::SP dirLight = light->as<DirLight>()) {
           dirLights.push_back(dirLight->getDD(instances.xfms[i]));
           continue;
@@ -123,16 +114,76 @@ namespace BARNEY_NS {
           continue;
         }
         if (EnvMapLight::SP el = light->as<EnvMapLight>()) {
-          envLight = {el,instances.xfms[i]};
+          envLight = {el, instances.xfms[i]};
           continue;
         }
         throw std::runtime_error("un-handled type of light!?");
       }
     }
-    world->set(envLight.first,envLight.second);
+    world->set(envLight.first, envLight.second);
     world->set(quadLights);
     world->set(dirLights);
     world->set(pointLights);
+  }
+
+  void ModelSlot::flattenInstancesForDevice(Device *device,
+                                            std::vector<rtc::Group *> *rtcGroups,
+                                            std::vector<affine3f> &rtcTransforms,
+                                            std::vector<int> *inputInstIDs)
+  {
+    for (int i = 0; i < (int)instances.groups.size(); i++) {
+      Group *group = instances.groups[i].get();
+      if (!group)
+        continue;
+      Group::PLD *groupPLD = group->getPLD(device);
+
+      auto append = [&](rtc::Group *rtcGroup) {
+        if (!rtcGroup)
+          return;
+        if (rtcGroups)
+          rtcGroups->push_back(rtcGroup);
+        rtcTransforms.push_back(instances.xfms[i]);
+        if (inputInstIDs)
+          inputInstIDs->push_back(i);
+      };
+
+      append(groupPLD->userGeomGroup);
+      append(groupPLD->volumeGeomsGroup);
+      append(groupPLD->triangleGeomGroup);
+      for (auto volumeGroup : groupPLD->volumeGroups)
+        append(volumeGroup);
+    }
+  }
+  
+  void ModelSlot::updateInstanceTransforms(const affine3f *xfms,
+                                           int numInstances)
+  {
+    if (numInstances != (int)instances.groups.size()) {
+      std::cout << "#barney: ignoring transform-only update with mismatched instance count"
+                << std::endl;
+      return;
+    }
+    std::copy(xfms, xfms + numInstances, instances.xfms.data());
+
+    updateWorldLightsFromInstances();
+
+    for (auto device : *devices) {
+      PLD *pld = getPLD(device);
+      if (!pld->instanceGroup)
+        continue;
+
+      std::vector<affine3f> rtcTransforms;
+      flattenInstancesForDevice(device, nullptr, rtcTransforms, nullptr);
+
+      pld->instanceGroup->setTransforms(rtcTransforms);
+      pld->instanceGroup->refitAccel();
+    }
+  }
+
+  void ModelSlot::build()
+  {
+    // Keep light extraction identical to transform-only updates.
+    updateWorldLightsFromInstances();
   
     // ==================================================================
     // generate all (per device) instance lists. note each BGGroup can
@@ -147,40 +198,10 @@ namespace BARNEY_NS {
       std::vector<affine3f>     rtcTransforms;
       std::vector<rtc::Group *> rtcGroups;
       bool firstDevice = (device == (*devices)[0]);
-      for (int i=0;i<instances.groups.size();i++) {
-        Group *group = instances.groups[i].get();
-        if (!group) continue;
-        Group::PLD *groupPLD = group->getPLD(device);
-      
-        if (groupPLD->userGeomGroup) {
-          rtcGroups.push_back(groupPLD->userGeomGroup);
-          rtcTransforms.push_back(instances.xfms[i]);
-          if (firstDevice)
-            inputInstIDs.push_back(i);
-          // if (!instances.userIDs.empty())
-          //   userIDs.push_back(instances.userIDs[i]);
-        }
-        if (groupPLD->volumeGeomsGroup) {
-          rtcGroups.push_back(groupPLD->volumeGeomsGroup);
-          rtcTransforms.push_back(instances.xfms[i]);
-          if (firstDevice)
-            inputInstIDs.push_back(i);
-        }
-
-        if (groupPLD->triangleGeomGroup) {
-          rtcGroups.push_back(groupPLD->triangleGeomGroup);
-          rtcTransforms.push_back(instances.xfms[i]);
-          if (firstDevice)
-            inputInstIDs.push_back(i);
-        }
-        
-        for (auto group : groupPLD->volumeGroups) {
-          rtcGroups.push_back(group);
-          rtcTransforms.push_back(instances.xfms[i]);
-          if (firstDevice)
-            inputInstIDs.push_back(i);
-        }
-      }
+      flattenInstancesForDevice(device,
+                                &rtcGroups,
+                                rtcTransforms,
+                                firstDevice ? &inputInstIDs : nullptr);
   
       if (pld->instanceGroup) {
         device->rtc->freeGroup(pld->instanceGroup);

--- a/barney/ModelSlot.h
+++ b/barney/ModelSlot.h
@@ -34,7 +34,13 @@ namespace BARNEY_NS {
     void setInstances(barney_api::Group **groups,
                       const affine3f *xfms,
                       int numInstances);
+    void updateInstanceTransforms(const affine3f *xfms, int numInstances);
     void setInstanceAttributes(const std::string &which, const PODData::SP &data);
+    void updateWorldLightsFromInstances();
+    void flattenInstancesForDevice(Device *device,
+                                   std::vector<rtc::Group *> *rtcGroups,
+                                   std::vector<affine3f> &rtcTransforms,
+                                   std::vector<int> *inputInstIDs);
 
     struct {
       std::vector<Group::SP> groups;

--- a/barney/api/Context.h
+++ b/barney/api/Context.h
@@ -157,6 +157,9 @@ namespace barney_api {
                               Group **groups,
                               const affine3f *xfms,
                               int numInstances) = 0;
+    virtual void updateInstanceTransforms(int slot,
+                                          const affine3f *xfms,
+                                          int numInstances) = 0;
     virtual void setInstanceAttributes(int slot,
                                        const std::string &which,
                                        Data::SP data) = 0;

--- a/barney/api/barney.cu
+++ b/barney/api/barney.cu
@@ -387,6 +387,18 @@ namespace barney_api {
                                   (const affine3f *)xfms,
                                   numInstances);
   }
+
+  BARNEY_API
+  void bnUpdateInstanceTransforms(BNModel model,
+                                  int slot,
+                                  BNTransform *xfms,
+                                  int numInstances)
+  {
+    LOG_API_ENTRY;
+    checkGet(model)->updateInstanceTransforms(slot,
+                                              (const affine3f *)xfms,
+                                              numInstances);
+  }
   
   BARNEY_API
   void  bnRelease(BNObject _object)

--- a/barney/include/barney.h
+++ b/barney/include/barney.h
@@ -379,6 +379,16 @@ void bnSetInstances(BNModel model,
                     BNTransform *instanceTransforms,
                     int numInstances);
 
+/*! update only the instance transforms for the given slot, reusing
+    existing group structures. This is much faster than bnSetInstances +
+    bnBuild when only transforms change (e.g., animation). The number of
+    instances must match what was previously set via bnSetInstances. */
+BARNEY_API
+void bnUpdateInstanceTransforms(BNModel model,
+                                int whichSlot,
+                                BNTransform *instanceTransforms,
+                                int numInstances);
+
 /*! allows for setting one of 5 attribute arrays for the given slot's
     model. */
 BARNEY_API

--- a/rtcore/cuda/Group.cu
+++ b/rtcore/cuda/Group.cu
@@ -107,7 +107,12 @@ namespace rtc {
       instBounds[tid] = xfmBounds(inst.objectToWorldXfm,bounds);
     }
 
-    void InstanceGroup::buildAccel() 
+    void InstanceGroup::setTransforms(const std::vector<affine3f> &newXfms)
+    {
+      xfms = newXfms;
+    }
+
+    void InstanceGroup::buildAccel()
     {
       SetActiveGPU forDuration(device);
 

--- a/rtcore/cuda/Group.h
+++ b/rtcore/cuda/Group.h
@@ -19,6 +19,7 @@ namespace rtc {
       virtual ~Group();
       virtual void buildAccel() = 0;
       virtual void refitAccel() { buildAccel(); }
+      virtual void setTransforms(const std::vector<affine3f> &) {}
       AccelHandle getDD() const { return (AccelHandle)d_accel; }
 
       Device *const device;
@@ -65,19 +66,20 @@ namespace rtc {
         cuBQL::bvh3f bvh;
         InstanceRecord *instanceRecords;
       };
-      
+
       InstanceGroup(Device *device,
                     const std::vector<Group *>  &groups,
                     const std::vector<int>      &instanceIDs,
                     const std::vector<affine3f> &xfms);
       void buildAccel() override;
+      void setTransforms(const std::vector<affine3f> &newXfms) override;
 
       DeviceRecord   *d_deviceRecord = 0;
       InstanceRecord *d_instanceRecords = 0;
       bvh3f bvh = { 0,0,0,0 };
       const std::vector<Group *>  groups;
       const std::vector<int>      instanceIDs;
-      const std::vector<affine3f> xfms;
+      std::vector<affine3f> xfms;
     };
     
     struct TrianglesGeomGroup : public GeomGroup {

--- a/rtcore/embree/Group.cpp
+++ b/rtcore/embree/Group.cpp
@@ -178,7 +178,12 @@ namespace rtc {
       return (GeomGroup*)g;
     }
     
-    void InstanceGroup::buildAccel() 
+    void InstanceGroup::setTransforms(const std::vector<affine3f> &newXfms)
+    {
+      xfms = newXfms;
+    }
+
+    void InstanceGroup::buildAccel()
     {
       embree::Device *device = (embree::Device *)this->device;
       if (embreeScene) {

--- a/rtcore/embree/Group.h
+++ b/rtcore/embree/Group.h
@@ -16,6 +16,7 @@ namespace rtc {
       virtual ~Group() = default;
       void refitAccel() { buildAccel(); }
       virtual void buildAccel() = 0;
+      virtual void setTransforms(const std::vector<affine3f> &) {}
       
       rtc::AccelHandle getDD() const
       {
@@ -67,8 +68,9 @@ namespace rtc {
                     const std::vector<affine3f> &xfms);
 
       GeomGroup *getGroup(int groupID);
-      
+
       void buildAccel() override;
+      void setTransforms(const std::vector<affine3f> &newXfms) override;
     
       std::vector<Group*>   groups;
       std::vector<affine3f> xfms;

--- a/rtcore/optix/Device.cpp
+++ b/rtcore/optix/Device.cpp
@@ -7,6 +7,7 @@
 #include "rtcore/optix/Buffer.h"
 #include "rtcore/optix/Geom.h"
 #include "rtcore/optix/Group.h"
+#include <owl/InstanceGroup.h>
 #include <optix.h>
 #include <optix_function_table.h>
 #include <optix_stubs.h>
@@ -211,7 +212,10 @@ namespace rtc {
                                  owls.size(),
                                  owls.data(),
                                  (const uint32_t*)instIDs.data(),
-                                 (const float *)xfms.data());
+                                 (const float *)xfms.data(),
+                                 OWL_MATRIX_FORMAT_OWL,
+                                 owl::InstanceGroup::defaultBuildFlags
+                                 | OPTIX_BUILD_FLAG_ALLOW_UPDATE);
       Group *gg = new Group(this,g);
       return gg;
     }

--- a/rtcore/optix/Group.cpp
+++ b/rtcore/optix/Group.cpp
@@ -25,10 +25,17 @@ namespace rtc {
       owlGroupBuildAccel(owl);
     }
     
-    void Group::refitAccel() 
+    void Group::refitAccel()
     {
       owlGroupRefitAccel(owl);
     }
-      
+
+    void Group::setTransforms(const std::vector<affine3f> &xfms)
+    {
+      owlInstanceGroupSetTransforms(owl, 0,
+                                    (const float *)xfms.data(),
+                                    OWL_MATRIX_FORMAT_OWL);
+    }
+
   }
 }

--- a/rtcore/optix/Group.h
+++ b/rtcore/optix/Group.h
@@ -18,6 +18,7 @@ namespace rtc {
       rtc::AccelHandle getDD() const;
       void buildAccel();
       void refitAccel();
+      void setTransforms(const std::vector<affine3f> &xfms);
       
       OWLGroup const owl;
       optix::Device *const device;


### PR DESCRIPTION
Get a lighter update path for instance transform updates, instead of fully rebuilding the acceleration structures hierarchy.

Mostly conservative as it is today, invalidating on surfaces, volumes and such.
Tries to limit the amount of work on the instancing update side.