### PR TITLE
Renderer updates

### DIFF
--- a/anari/Frame.cpp
+++ b/anari/Frame.cpp
@@ -119,6 +119,7 @@ namespace barney_device {
 
       if (m_bnFrameBuffer) {
         bnSet1i(m_bnFrameBuffer, "denoise", m_renderer->denoise() ? 1 : 0);
+        bnSet1i(m_bnFrameBuffer, "fadeOutDenoiser", m_renderer->fadeOutDenoiser() ? 1 : 0);
         bnSet1i(m_bnFrameBuffer, "upscale", m_renderer->upscale() ? 1 : 0);
         bnCommit(m_bnFrameBuffer);
 

--- a/anari/Frame.cpp
+++ b/anari/Frame.cpp
@@ -80,15 +80,12 @@ namespace barney_device {
       getParam<anari::DataType>("channel.normal", ANARI_UNKNOWN);
     m_size = getParam<math::uint2>("size", math::uint2(10, 10));
     m_displaySize = m_size;  /* updated in finalize() from actual FB when slot==0 */
-    m_enableDenoising = getParam<bool>("denoise", false);
-    m_enableUpscaling = getParam<bool>("upscale", false);
   }
 
   void Frame::finalize()
   {
     cleanup();
 
-    bool denoise = m_enableDenoising;
     if (!m_renderer) {
       reportMessage(ANARI_SEVERITY_WARNING,
                     "missing required parameter 'renderer' on frame");
@@ -109,7 +106,7 @@ namespace barney_device {
       const auto numPixels = size.x * size.y;
 
       uint32_t requiredChannels = BN_FB_COLOR;
-      if (m_channelTypes.depth == ANARI_FLOAT32) 
+      if (m_channelTypes.depth == ANARI_FLOAT32)
         requiredChannels |= BN_FB_DEPTH;
       if (m_channelTypes.primID == ANARI_UINT32)
         requiredChannels |= BN_FB_PRIMID;
@@ -121,8 +118,8 @@ namespace barney_device {
         requiredChannels |= BN_FB_NORMAL;
 
       if (m_bnFrameBuffer) {
-        bnSet1i(m_bnFrameBuffer, "denoise", denoise ? 1 : 0);
-        bnSet1i(m_bnFrameBuffer, "upscale", m_enableUpscaling ? 1 : 0);
+        bnSet1i(m_bnFrameBuffer, "denoise", m_renderer->denoise() ? 1 : 0);
+        bnSet1i(m_bnFrameBuffer, "upscale", m_renderer->upscale() ? 1 : 0);
         bnCommit(m_bnFrameBuffer);
 
         bnFrameBufferResize(m_bnFrameBuffer,
@@ -191,7 +188,7 @@ namespace barney_device {
     }
 
     auto model = m_world->makeCurrent();
-    
+
     if (m_lastFrameWasFirstFrame && m_channelTypes.depth != ANARI_UNKNOWN
         && !m_didMapChannel.depth)
       reportMessage(ANARI_SEVERITY_PERFORMANCE_WARNING,

--- a/anari/Frame.h
+++ b/anari/Frame.h
@@ -49,8 +49,6 @@ namespace barney_device {
     void cleanup();
 
     bool        m_valid           {false};
-    bool        m_enableDenoising {true};
-    bool        m_enableUpscaling {false};
     math::uint2 m_size            { 0,0 };
     /*! Actual framebuffer dimensions (from bnFrameBufferGetSize after
         resize). Matches buffer layout so map() reports correct stride. */

--- a/anari/Group.cpp
+++ b/anari/Group.cpp
@@ -54,7 +54,6 @@ namespace barney_device {
                       else {
                         reportMessage(ANARI_SEVERITY_WARNING,
                                       "encountered invalid surface (%p)",
-                                      this,
                                       s);
                       }
                     });
@@ -77,7 +76,6 @@ namespace barney_device {
                       else {
                         reportMessage(ANARI_SEVERITY_WARNING,
                                       "encountered invalid volume (%p)",
-                                      this,
                                       v);
                       }
                     });
@@ -97,8 +95,7 @@ namespace barney_device {
                         lights.push_back(l);
                       else {
                         reportMessage(ANARI_SEVERITY_WARNING,
-                                      "encountered invalid volume (%p)",
-                                      this,
+                                      "encountered invalid light (%p)",
                                       l);
                       }
                     });

--- a/anari/Renderer.cpp
+++ b/anari/Renderer.cpp
@@ -23,6 +23,7 @@ void Renderer::commitParameters()
   m_ambientRadiance = getParam<float>("ambientRadiance", 1.f);
   m_crosshairs = getParam<bool>("crosshairs", false);
   m_denoise = getParam<bool>("denoise", true);
+  m_fadeOutDenoiser = getParam<bool>("fadeOutDenoiser", true);
   m_upscale = getParam<bool>("upscale", false);
   m_background = getParam<math::float4>("background", math::float4(0, 0, 0, 1));
   m_backgroundImage = getParamObject<Array2D>("background");
@@ -68,6 +69,11 @@ bool Renderer::crosshairs() const
 bool Renderer::denoise() const
 {
   return m_denoise;
+}
+
+bool Renderer::fadeOutDenoiser() const
+{
+  return m_fadeOutDenoiser;
 }
 
 bool Renderer::upscale() const

--- a/anari/Renderer.cpp
+++ b/anari/Renderer.cpp
@@ -23,6 +23,7 @@ void Renderer::commitParameters()
   m_ambientRadiance = getParam<float>("ambientRadiance", 1.f);
   m_crosshairs = getParam<bool>("crosshairs", false);
   m_denoise = getParam<bool>("denoise", true);
+  m_upscale = getParam<bool>("upscale", false);
   m_background = getParam<math::float4>("background", math::float4(0, 0, 0, 1));
   m_backgroundImage = getParamObject<Array2D>("background");
   m_cutPlane = getParam<math::float4>("cutPlane", math::float4(0, 0, 0, 0));
@@ -67,6 +68,11 @@ bool Renderer::crosshairs() const
 bool Renderer::denoise() const
 {
   return m_denoise;
+}
+
+bool Renderer::upscale() const
+{
+  return m_upscale;
 }
 
 bool Renderer::isValid() const

--- a/anari/Renderer.h
+++ b/anari/Renderer.h
@@ -19,6 +19,7 @@ namespace barney_device {
 
     bool crosshairs() const;
     bool denoise() const;
+    bool fadeOutDenoiser() const;
     bool upscale() const;
     bool isValid() const override;
 
@@ -31,6 +32,7 @@ namespace barney_device {
     float m_ambientRadiance{0.8f};
     bool m_crosshairs{false};
     bool m_denoise{true};
+    bool m_fadeOutDenoiser{true};
     bool m_upscale{false};
     anari::math::float4 m_background{0.f, 0.f, 0.f, 1.f};
     anari::math::float4 m_cutPlane{0.f, 0.f, 0.f, -1e30f};

--- a/anari/Renderer.h
+++ b/anari/Renderer.h
@@ -19,6 +19,7 @@ namespace barney_device {
 
     bool crosshairs() const;
     bool denoise() const;
+    bool upscale() const;
     bool isValid() const override;
 
     BNRenderer barneyRenderer{nullptr};
@@ -30,6 +31,7 @@ namespace barney_device {
     float m_ambientRadiance{0.8f};
     bool m_crosshairs{false};
     bool m_denoise{true};
+    bool m_upscale{false};
     anari::math::float4 m_background{0.f, 0.f, 0.f, 1.f};
     anari::math::float4 m_cutPlane{0.f, 0.f, 0.f, -1e30f};
     helium::ChangeObserverPtr<Array2D> m_backgroundImage;

--- a/anari/barney_device.json
+++ b/anari/barney_device.json
@@ -63,6 +63,15 @@
           "description": "denoise image"
         },
         {
+          "name": "upscale",
+          "types": [
+            "ANARI_BOOL"
+          ],
+          "tags": [],
+          "default": false,
+          "description": "upscale image"
+        },
+        {
           "name": "crosshairs",
           "types": [
             "ANARI_BOOL"

--- a/anari/barney_device.json
+++ b/anari/barney_device.json
@@ -63,6 +63,15 @@
           "description": "denoise image"
         },
         {
+          "name": "fadeOutDenoiser",
+          "types": [
+            "ANARI_BOOL"
+          ],
+          "tags": [],
+          "default": true,
+          "description": "fade out denoiser during accumulation"
+        },
+        {
           "name": "upscale",
           "types": [
             "ANARI_BOOL"

--- a/barney/fb/FrameBuffer.cu
+++ b/barney/fb/FrameBuffer.cu
@@ -62,6 +62,10 @@ namespace BARNEY_NS {
       enableDenoising = value;
       return true;
     }
+    if (member == "fadeOutDenoiser") {
+      fadeOutDenoiser = value;
+      return true;
+    }
     if (member == "upscale") {
       enableUpscaling = value;
       return true;
@@ -242,7 +246,7 @@ namespace BARNEY_NS {
 
     bool doDenoising = denoiser != 0 && (enableDenoising || enableUpscaling);
     if (doDenoising) {
-      float blendFactor = (accumID-1) / (accumID+100.f);
+      float blendFactor = fadeOutDenoiser ? (accumID-1) / (accumID+100.f) : 0.f;
       device->rtc->sync();
       denoiser->run(blendFactor);
 
@@ -295,7 +299,7 @@ namespace BARNEY_NS {
     device->rtc->sync();
   }
 
-  
+
   /*! "finalize" and read the frame buffer. If this function gets
       called with a null hostPtr we will still finalize the frame
       buffer and run the denoiser, just not copy it to host; the
@@ -337,7 +341,7 @@ namespace BARNEY_NS {
       }
       return;
     }
-    
+
     Device *device = getDenoiserDevice();
     SetActiveGPU forDuration(device);
 

--- a/barney/fb/FrameBuffer.h
+++ b/barney/fb/FrameBuffer.h
@@ -37,7 +37,7 @@ namespace BARNEY_NS {
     void freeResources();
 
     bool needHitIDs() const;
-    
+
     void finalizeTiles();
     void finalizeFrame();
 
@@ -49,7 +49,7 @@ namespace BARNEY_NS {
                                     BNDataType gatherType,
                                     // can be null:
                                     vec3f *linearNormal) = 0;
-    
+
     /*! read one of the auxiliary (not color or normal) buffers into
       the given app memory; this will at the least incur some
       reformatting from tiles to linear (if local node), possibly
@@ -58,7 +58,7 @@ namespace BARNEY_NS {
     virtual void gatherAuxChannel(BNFrameBufferChannel channel) = 0;
     virtual void writeAuxChannel(void *stagingArea,
                                  BNFrameBufferChannel channel) = 0;
-    
+
     /*! read given frame buffer channel into given application memory
         (which may be either host or device memory), in requested
         format. Requeseted color format (currently) has to match the
@@ -74,17 +74,17 @@ namespace BARNEY_NS {
     PLD *getPLD(Device *device);
 
     std::vector<PLD> perLogical;
-    
+
     /*! staging area for gathering/writing pixels into, will be Nx*Ny
         pixels of type as provided specified during resize. This may
         point to either float4 or rgba8 depending on requested
         format */
     void *linearColorChannel = 0;
-    
+
     /*! staging area for re-assembling any other channel; note this
         may store either float or uint32 data */
     void *linearAuxChannel = 0;
-    
+
     /*! staging area for the normal channel (vec3f per pixel) */
     void *linearNormalChannel = 0;
 
@@ -96,7 +96,7 @@ namespace BARNEY_NS {
     /*! when upscaling, staging for 2x upscaled color (float4 at numPixels)
         before convert/copy to app (denoiser runs at half res, we upscale here) */
     void  *upscaledColorChannel = 0;
-    
+
     /*! the channels we're supposed to have (as asked for on the latest resize()) */
     uint32_t   channels = 0;
     BNDataType colorChannelFormat = BN_DATA_UNDEFINED;
@@ -121,7 +121,7 @@ namespace BARNEY_NS {
     /*! @} */
     // ------------------------------------------------------------------
 
-    
+
     /*! points to the rtc denoiser object we've created. Can be null
         if denoising is disabled in cmake, or if the given rtc backend
         doesn't support denoising (eg, old optix version, oidn not
@@ -133,6 +133,8 @@ namespace BARNEY_NS {
      require an rtc backend that does have a denoiser (\see denoiser
      field), but this allows a user to disable denoising at runtime */
     bool enableDenoising = 1;
+
+    bool fadeOutDenoiser = true;
 
     /*! whether to use OptiX AI 2x upscaling. When enabled, tiles
         render at half resolution and the denoiser upscales to the
@@ -147,7 +149,7 @@ namespace BARNEY_NS {
     /*! kernel that converts from a linear device-side float4 format
         to a linear device-side ufixed8 format */
     rtc::ComputeKernel2D *linear_toFixed8 = 0;
-    
+
     const bool  isOwner;
     bool  showCrosshairs = false;
     DevGroup::SP const devices;


### PR DESCRIPTION
Changes:

- Put `denoise` and `upscale` parameters on the ANARI renderer
- Fix incorrect error messages in `ANARIGroup`
- Add a parameter to permit turning off the "blend the denoised image away" after a set of samples (some scenes don't converge to a noiseless image). 