### PR TITLE
Fix Spheres geometry: remove debug leftover that clobbered instID

### DIFF
--- a/barney/geometry/Spheres.dev.cu
+++ b/barney/geometry/Spheres.dev.cu
@@ -191,8 +191,6 @@ namespace BARNEY_NS {
               = world.instIDToUserInstID
               ? world.instIDToUserInstID[instID]
               : instID;
-            globals.hitIDs[rayID].instID
-              = 13+world.rank;
             globals.hitIDs[rayID].objID  = self.userID;
             globals.hitIDs[rayID].depth  = depth;
           }


### PR DESCRIPTION
Spheres.dev.cu:194-195 overwrote the correctly-computed instance ID (from world.instIDToUserInstID[] or the raw instID) with '13 + world.rank' immediately after computing it. This appears to be a debug/test leftover.