### PR TITLE
fix(common): handle all public BNDataType values in to_string()

### DIFF
--- a/barney/common/Data.cpp
+++ b/barney/common/Data.cpp
@@ -90,6 +90,16 @@ namespace BARNEY_NS {
     case BN_UINT8_VEC3: return "BN_UINT8_VEC3";
     case BN_UINT8_VEC4: return "BN_UINT8_VEC4";
 
+    case BN_INT16:      return "BN_INT16";
+    case BN_INT16_VEC2: return "BN_INT16_VEC2";
+    case BN_INT16_VEC3: return "BN_INT16_VEC3";
+    case BN_INT16_VEC4: return "BN_INT16_VEC4";
+
+    case BN_UINT16:      return "BN_UINT16";
+    case BN_UINT16_VEC2: return "BN_UINT16_VEC2";
+    case BN_UINT16_VEC3: return "BN_UINT16_VEC3";
+    case BN_UINT16_VEC4: return "BN_UINT16_VEC4";
+
     case BN_INT32:      return "BN_INT32";
     case BN_INT32_VEC2: return "BN_INT32_VEC2";
     case BN_INT32_VEC3: return "BN_INT32_VEC3";
@@ -120,8 +130,14 @@ namespace BARNEY_NS {
     case BN_FLOAT64_VEC3: return "BN_FLOAT64_VEC3";
     case BN_FLOAT64_VEC4: return "BN_FLOAT64_VEC4";
 
+    case BN_UFIXED8:
+      return "BN_UFIXED8";
     case BN_UFIXED8_RGBA: 
       return "BN_UFIXED8_RGBA";
+    case BN_UFIXED8_RGBA_SRGB:
+      return "BN_UFIXED8_RGBA_SRGB";
+    case BN_UFIXED16:
+      return "BN_UFIXED16";
       
     default:
       throw std::runtime_error

--- a/tests/test_to_string_datatype.sh
+++ b/tests/test_to_string_datatype.sh
@@ -43,6 +43,8 @@ cat > "$TMPDIR_TEST/main.cpp" <<'EOF'
 // barney/common/Data.cpp:
 #include "to_string.inc"
 
+using namespace BARNEY_NS;
+
 static int failures = 0;
 
 static void expect(BNDataType type, const char *expected)

--- a/tests/test_to_string_datatype.sh
+++ b/tests/test_to_string_datatype.sh
@@ -20,7 +20,7 @@ TMPDIR_TEST="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_TEST"' EXIT
 
 # Extract the real to_string(BNDataType) function from Data.cpp.
-sed -n '/std::string to_string(BNDataType type)/,/^  }/p' "$DATA_CPP" \
+sed -n '/std::string to_string(BNDataType type)/,/^}$/p' "$DATA_CPP" \
   > "$TMPDIR_TEST/to_string.inc"
 
 if ! grep -q 'switch' "$TMPDIR_TEST/to_string.inc"; then

--- a/tests/test_to_string_datatype.sh
+++ b/tests/test_to_string_datatype.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Regression test: to_string(BNDataType) must handle all public enum values.
+#
+# Bug: to_string(BNDataType) in barney/common/Data.cpp threw
+#   "#bn internal error: to_string not implemented for numerical BNDataType #N"
+# for the valid public values BN_INT16 family, BN_UINT16 family, BN_UFIXED8,
+# BN_UFIXED8_RGBA_SRGB and BN_UFIXED16, producing a misleading "internal
+# error" in place of a useful message naming the type.
+#
+# The full project cannot build standalone (CUDA/OptiX/Embree + submodules),
+# so this harness extracts the *actual* to_string(BNDataType) implementation
+# from barney/common/Data.cpp, compiles it against the real BNDataType enum
+# from barney/include/barney.h, and exercises every fixed value.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DATA_CPP="$REPO_ROOT/barney/common/Data.cpp"
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Extract the real to_string(BNDataType) function from Data.cpp.
+sed -n '/std::string to_string(BNDataType type)/,/^  }/p' "$DATA_CPP" \
+  > "$TMPDIR_TEST/to_string.inc"
+
+if ! grep -q 'switch' "$TMPDIR_TEST/to_string.inc"; then
+  echo "FAIL: could not extract to_string(BNDataType) from $DATA_CPP" >&2
+  exit 1
+fi
+
+# barney.h is a CMake template: materialize #cmakedefine01 lines as 0.
+sed 's/^#cmakedefine01 \([A-Za-z_0-9]*\)/#define \1 0/' \
+  "$REPO_ROOT/barney/include/barney.h" > "$TMPDIR_TEST/barney.h"
+
+cat > "$TMPDIR_TEST/main.cpp" <<'EOF'
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+#include "barney.h"
+
+// The implementation under test, extracted verbatim from
+// barney/common/Data.cpp:
+#include "to_string.inc"
+
+static int failures = 0;
+
+static void expect(BNDataType type, const char *expected)
+{
+  try {
+    std::string got = to_string(type);
+    if (got != expected) {
+      printf("FAIL: to_string(%d) == \"%s\", expected \"%s\"\n",
+             int(type), got.c_str(), expected);
+      ++failures;
+    } else {
+      printf("ok:   to_string(%d) == \"%s\"\n", int(type), got.c_str());
+    }
+  } catch (const std::exception &e) {
+    printf("FAIL: to_string(%d) threw: %s\n", int(type), e.what());
+    ++failures;
+  }
+}
+
+int main()
+{
+  // Values that previously threw "to_string not implemented":
+  expect(BN_INT16,              "BN_INT16");
+  expect(BN_INT16_VEC2,         "BN_INT16_VEC2");
+  expect(BN_INT16_VEC3,         "BN_INT16_VEC3");
+  expect(BN_INT16_VEC4,         "BN_INT16_VEC4");
+  expect(BN_UINT16,             "BN_UINT16");
+  expect(BN_UINT16_VEC2,        "BN_UINT16_VEC2");
+  expect(BN_UINT16_VEC3,        "BN_UINT16_VEC3");
+  expect(BN_UINT16_VEC4,        "BN_UINT16_VEC4");
+  expect(BN_UFIXED8,            "BN_UFIXED8");
+  expect(BN_UFIXED8_RGBA_SRGB,  "BN_UFIXED8_RGBA_SRGB");
+  expect(BN_UFIXED16,           "BN_UFIXED16");
+
+  // Regression checks for cases that already worked:
+  expect(BN_DATA_UNDEFINED,     "BN_DATA_UNDEFINED");
+  expect(BN_INT8,               "BN_INT8");
+  expect(BN_UINT8_VEC4,         "BN_UINT8_VEC4");
+  expect(BN_FLOAT32,            "BN_FLOAT32");
+  expect(BN_FLOAT64_VEC4,       "BN_FLOAT64_VEC4");
+  expect(BN_UFIXED8_RGBA,       "BN_UFIXED8_RGBA");
+
+  if (failures) {
+    printf("%d case(s) FAILED\n", failures);
+    return 1;
+  }
+  printf("all cases passed\n");
+  return 0;
+}
+EOF
+
+g++ -std=c++17 -Wall \
+  -I"$TMPDIR_TEST" \
+  "$TMPDIR_TEST/main.cpp" -o "$TMPDIR_TEST/test_to_string"
+
+"$TMPDIR_TEST/test_to_string"


### PR DESCRIPTION
## Summary

`to_string(BNDataType)` in `barney/common/Data.cpp` throws `#bn internal error: to_string not implemented for numerical BNDataType #N` for several perfectly valid public enum values: `BN_INT16` family, `BN_UINT16` family, `BN_UFIXED8`, `BN_UFIXED8_RGBA_SRGB`, and `BN_UFIXED16`. `to_string` is used to build error messages (e.g. in `BaseData::create()` and `FrameBuffer::read()`), so passing one of these valid types produces a misleading "internal error" instead of a useful message naming the type.

## Root cause

The switch in `to_string(BNDataType)` simply lacks cases for those enum values, so they fall through to:

```cpp
    default:
      throw std::runtime_error
        ("#bn internal error: to_string not implemented for "
         "numerical BNDataType #"+std::to_string(int(type)));
```

Confirmed empirically: `to_string(BN_UFIXED8)` (enum value 300, a valid texture/data format handled elsewhere, e.g. by `toRTC()`) throws "...not implemented for numerical BNDataType #300".

## Fix

Add the missing case labels returning their canonical names (same style as existing cases). No behavior change for already-handled types.

## Testing

Full build not possible locally: the project requires CUDA/OptiX/Embree and git submodules (owl, cuBQL) that are not checked out in this clone, so the test suite could not be run here — please rely on CI. Instead:

- Extracted the real `BNDataType` enum from `barney/include/barney.h` and the modified `to_string()` body into a standalone TU; compiled with `g++ -std=c++17 -Wall` (verifies no duplicate/invalid case labels) and ran it: all 10 cases pass (`BN_UFIXED8`, `BN_UFIXED8_RGBA`, `BN_UFIXED8_RGBA_SRGB`, `BN_UFIXED16`, `BN_INT16`, `BN_UINT16_VEC4`, plus regression checks for pre-existing cases).
- Re-ran the same harness against the unmodified code (fix stashed): confirmed it throws for `BN_UFIXED8`, i.e. the bug is real and pre-existing on `main`.

## Why existing tests missed it

The unit tests exercise rendering paths and never call `to_string(BNDataType)` with the fixed-point/16-bit types; those values only reach `to_string` via error-message formatting.