### PR TITLE
Add sampleLimit parameter on renderer (max. accumulation count)

### DIFF
--- a/barney/anari/Renderer.cpp
+++ b/barney/anari/Renderer.cpp
@@ -34,6 +34,7 @@ namespace BARNEY_NS {
          be only two possible configs for multiscatter: which voluem
          type (ie which phase function), and then how many bounces */
       m_maxVolumeBounces = getParam<int>("maxVolumeBounces", 0);
+      m_sampleLimit = std::clamp(getParam<int>("sampleLimit", 1024), 1, INT_MAX);
       // m_maxVolumeBounces = getParam<int>("maxVolumeBounces", 8);
     }
 
@@ -44,6 +45,7 @@ namespace BARNEY_NS {
       bnSet1i(barneyRenderer, "pathsPerPixel", (int)m_pixelSamples);
       bnSet1f(barneyRenderer, "ambientRadiance", m_ambientRadiance);
       bnSet1i(barneyRenderer, "maxVolumeBounces", m_maxVolumeBounces);
+      bnSet1i(barneyRenderer, "sampleLimit", m_sampleLimit);
       // bnSet1i(barneyRenderer, "volumeMultiScatter", (int)m_volumeMultiScatter);
       bnSet4f(barneyRenderer, "cutPlane",
               m_cutPlane.x, m_cutPlane.y, m_cutPlane.z, m_cutPlane.w);

--- a/barney/anari/Renderer.h
+++ b/barney/anari/Renderer.h
@@ -38,6 +38,7 @@ namespace BARNEY_NS {
       anari::math::float4 m_background{0.f, 0.f, 0.f, 1.f};
       anari::math::float4 m_cutPlane{0.f, 0.f, 0.f, -1e30f};
       int m_maxVolumeBounces{8};
+      int m_sampleLimit{1024};
       helium::ChangeObserverPtr<Array2D> m_backgroundImage;
     };
 

--- a/barney/anari/json/cpu/barney_device.json
+++ b/barney/anari/json/cpu/barney_device.json
@@ -53,6 +53,14 @@
           "description": "number of pixel samples per-frame"
         },
         {
+          "name": "sampleLimit",
+          "types": ["ANARI_INT32"],
+          "tags": [],
+          "default": 1024,
+          "minimum": 0,
+          "description": "stop refining the frame after this number of samples"
+        },
+        {
           "name": "denoise",
           "types": [
             "ANARI_BOOL"

--- a/barney/anari/json/cuda/barney_device.json
+++ b/barney/anari/json/cuda/barney_device.json
@@ -54,6 +54,14 @@
           "description": "number of pixel samples per-frame"
         },
         {
+          "name": "sampleLimit",
+          "types": ["ANARI_INT32"],
+          "tags": [],
+          "default": 1024,
+          "minimum": 0,
+          "description": "stop refining the frame after this number of samples"
+        },
+        {
           "name": "denoise",
           "types": [
             "ANARI_BOOL"

--- a/barney/anari/json/hip/barney_device.json
+++ b/barney/anari/json/hip/barney_device.json
@@ -53,6 +53,14 @@
           "description": "number of pixel samples per-frame"
         },
         {
+          "name": "sampleLimit",
+          "types": ["ANARI_INT32"],
+          "tags": [],
+          "default": 1024,
+          "minimum": 0,
+          "description": "stop refining the frame after this number of samples"
+        },
+        {
           "name": "denoise",
           "types": [
             "ANARI_BOOL"

--- a/barney/anari/json/hiprt/barney_device.json
+++ b/barney/anari/json/hiprt/barney_device.json
@@ -53,6 +53,14 @@
           "description": "number of pixel samples per-frame"
         },
         {
+          "name": "sampleLimit",
+          "types": ["ANARI_INT32"],
+          "tags": [],
+          "default": 1024,
+          "minimum": 0,
+          "description": "stop refining the frame after this number of samples"
+        },
+        {
           "name": "denoise",
           "types": [
             "ANARI_BOOL"

--- a/barney/anari/json/optix/barney_device.json
+++ b/barney/anari/json/optix/barney_device.json
@@ -54,6 +54,14 @@
           "description": "number of pixel samples per-frame"
         },
         {
+          "name": "sampleLimit",
+          "types": ["ANARI_INT32"],
+          "tags": [],
+          "default": 1024,
+          "minimum": 0,
+          "description": "stop refining the frame after this number of samples"
+        },
+        {
           "name": "denoise",
           "types": [
             "ANARI_BOOL"

--- a/barney/native/LocalContext.cpp
+++ b/barney/native/LocalContext.cpp
@@ -6,6 +6,7 @@
 #include "native/fb/LocalFB.h"
 #include "native/globalTrace/RQSLocal.h"
 #include "native/render/RayQueue.h"
+#include "native/render/Renderer.h"
 #include "native/WorkerTopo.h"
 
 namespace BARNEY_NS {
@@ -81,6 +82,9 @@ namespace BARNEY_NS {
     {
       assert(model);
       assert(fb);
+
+      if (fb->accumID >= renderer->sampleLimit)
+        return;
 
       renderTiles(renderer,model,camera,fb);
       finalizeTiles(fb);

--- a/barney/native/render/Renderer.cpp
+++ b/barney/native/render/Renderer.cpp
@@ -31,6 +31,7 @@ namespace BARNEY_NS {
       bgTexture       = staged.bgTexture;
       cutPlane        = staged.cutPlane;
       maxVolumeBounces = staged.maxVolumeBounces;
+      sampleLimit     = staged.sampleLimit;
       // volumeMultiScatter = staged.volumeMultiScatter;
     }
   
@@ -71,6 +72,10 @@ namespace BARNEY_NS {
       }
       if (member == "maxVolumeBounces") {
         staged.maxVolumeBounces = value;
+        return true;
+      }
+      if (member == "sampleLimit") {
+        staged.sampleLimit = value;
         return true;
       }
       // if (member == "volumeMultiScatter") {

--- a/barney/native/render/Renderer.h
+++ b/barney/native/render/Renderer.h
@@ -57,6 +57,7 @@ namespace BARNEY_NS {
         int         crosshairs;
         int         maxVolumeBounces;
         int         volumeMultiScatter;
+        int         sampleLimit;
       } staged;
       vec4f       bgColor         = vec4f(0,0,0,1.f);
       Texture::SP bgTexture       = 0;
@@ -75,6 +76,8 @@ namespace BARNEY_NS {
       int         maxVolumeBounces = 0;// ap original value: 8;
       /* iw - @ap: axed this; setting maxbounces to 0 should do the trick? */
       // int         volumeMultiScatter = 1;
+      // maximum number of samples accumulated:
+      int         sampleLimit = 1024;
     };
 
   }


### PR DESCRIPTION
This controls how many frames are accumulated. The parameter name is the same as used by other devices.

This parameter would also enable tracking the rendering progress, in conjunction with the frame property `refinementProgress`. Tracking that would require extending the native C-API to query the sample limit and current accumulation ID, though.